### PR TITLE
adding in rerunning

### DIFF
--- a/crates/otl-data/client.data.proto
+++ b/crates/otl-data/client.data.proto
@@ -9,12 +9,14 @@ message ClientCommand {
     SetCommands setter = 1;
     RunOne runone = 2;
     RunType runtype = 3;
+    RunMany runmany = 4;
   }
 }
 
 message SetCommands { string command_content = 1; }
 
 message RunOne { string command_name = 1; }
+message RunMany { repeated string command_names= 1; }
 
 message RunType {
   // Eventually, perhaps we should encode this as info in protobuf

--- a/crates/otl-data/src/client_commands.rs
+++ b/crates/otl-data/src/client_commands.rs
@@ -21,6 +21,14 @@ impl ClientCommand {
         }
     }
 
+    pub fn execute_many(command_names: Vec<String>) -> Self {
+        let cc = ClientCommands::Runmany(RunMany { command_names });
+
+        ClientCommand {
+            client_commands: Some(cc),
+        }
+    }
+
     pub fn execute_type(typeinfo: String) -> Self {
         let cc = ClientCommands::Runtype(RunType { typeinfo });
 

--- a/py-otl/pyotl/cli.py
+++ b/py-otl/pyotl/cli.py
@@ -2,14 +2,15 @@ from typing_extensions import Annotated
 from pathlib import Path
 import typer
 import yaml
-from pyotl.pygraph import PyGraph
 from pyotl.rc import OtlRC
 from pyotl.importer import get_all_targets
 from pyotl.interfaces import OtlTargetType
-from pyotl.otl_muncher import create_graph, parse_otl
+from pyotl.otl_muncher import parse_otl
+from pyotl.pygraph import create_graph
 from pyotl.serde import SafeDataclassDumper
 from pyotl.pyotlexec.naive import execute_command_list
 from typing import Optional
+from typer import Typer, Argument, Exit
 
 app = typer.Typer()
 
@@ -69,10 +70,6 @@ def targets(
     print(targets)
 
 
-from typing import Any
-from typer import Typer, Argument, Exit
-
-
 def validate_type(value: str):
     if value not in OtlTargetType._value2member_map_:
         raise Exit(
@@ -98,6 +95,7 @@ def execute(
     otl_file: TlPath,
     tt: str = typer.Option("test", help="OTL target type", callback=validate_type),
     target_name: Optional[str] = typer.Option(None, help="Target name"),
+    rerun: bool = typer.Option(False, help="Rerun the command", is_flag=True),
     help="Goes through the entire flow, from otl file to executing a command list",
 ):
 
@@ -106,6 +104,8 @@ def execute(
         graph.run_one_test(target_name)
     else:
         graph.run_all_tests(tt)
+    if rerun:
+        graph.rerun()
 
 
 def main():

--- a/py-otl/pyotl/interfaces/command.py
+++ b/py-otl/pyotl/interfaces/command.py
@@ -9,11 +9,22 @@ CommandRef = str
 
 @dataclass
 class Command:
+    """
+    The simplest unit of compute in otl -- commands are the nodes that are scheduled and executed by the runtime
+
+    Functionally, Command is a simple wrapper around a `bash` script
+    """
+
     name: str
-    # todo: this really needs to be an otl target type literal, but i am too annoyed at pyright now to figure it out
     target_type: str
     script: List[str]
+    """
+    A list of bash commands that will be executed in sequence
+    """
     dependencies: List[CommandRef]
+    """
+    Paths to files this command creates
+    """
     outputs: List[str]
     runtime: RuntimeRequirements
 

--- a/py-otl/pyotl/interfaces/target.py
+++ b/py-otl/pyotl/interfaces/target.py
@@ -18,6 +18,12 @@ TargetRef = str
 
 @dataclass
 class Target(ABC):
+    """
+    A target is a structure that holds logic to generate a `Command`
+
+    Targets are higher level abstraction to generate a new command based off of certain new input criterea -- for instance, if a target fails, and you create a new command
+    """
+
     name: str
 
     def get_outputs(self) -> Dict[str, OtlPath]:

--- a/py-otl/pyotl/otl_muncher.py
+++ b/py-otl/pyotl/otl_muncher.py
@@ -1,12 +1,11 @@
 from dataclasses import dataclass
 import yaml
-from typing import Dict, Any, Tuple, Type, List
+from typing import Dict, Any, Iterable, Tuple, Type, List
 from pydantic import BaseModel
 from pyotl.importer import DocumentedTarget, get_all_targets, get_default_targets
 from pyotl.interfaces import Target, Command
 from pyotl.rc import OtlRC, OtlRcHolder
 from pyotl.path_utils import get_git_root
-from pyotl.pygraph import PyGraph
 
 
 class SerYamlTarget(BaseModel):
@@ -49,12 +48,19 @@ def parse_otl(
     targets = otl_contents_to_targets(
         yaml_content, default_rules_only=default_rules_only
     )
+    command_list = lower_target_to_command(targets.values())
+
+    return targets, command_list
+
+
+def lower_target_to_command(targets: Iterable[Target]):
+
     rc = OtlRcHolder.current_rc
     command_list = [
         Command.from_target(otl_target, default_root=rc.otl_default_root)
-        for otl_target in targets.values()
+        for otl_target in targets
     ]
-    return targets, command_list
+    return command_list
 
 
 def otl_contents_to_targets(
@@ -75,8 +81,3 @@ def otl_contents_to_targets(
         for target in yaml_targets
     }
     return {name: to_target(pre_target) for name, pre_target in pre_targets.items()}
-
-
-def create_graph(test_list: str) -> PyGraph:
-    targets, command_list = parse_otl(test_list)
-    return PyGraph.init(targets, command_list)

--- a/py-otl/pyotl/pygraph.py
+++ b/py-otl/pyotl/pygraph.py
@@ -1,7 +1,7 @@
-from typing import Dict, List, Optional, Tuple
-from pyotl.interfaces import Command, OtlTargetType
+from typing import Callable, Dict, List, Optional, Tuple, cast
+from pyotl.interfaces import Command, OtlTargetType, Target
 from dataclasses import dataclass
-from pyotl.interfaces.target import Target
+from pyotl.otl_muncher import lower_target_to_command, parse_otl
 from pyotl.pyotl import PyController, PySubscriber
 import yaml
 import time
@@ -12,6 +12,22 @@ from pyotl.otl_telemetry.data import Event
 
 from pyotl.subscribers.is_done import IsDoneSubscriber
 from pyotl.subscribers.output_collector import OutputConsole
+from pyotl.subscribers.retcode import RetcodeTracker
+
+from copy import deepcopy
+
+
+def default_target_rerun_callback(target: Target, return_code: int) -> Optional[Target]:
+    """
+    First pass at re-run logic -- currently we just rerun all tests that are tagged as tests
+
+    Power users could supply their own logic, but we should define something that is robust and sane
+    """
+
+    if target.rule_type() == OtlTargetType.Test:
+        new_target = deepcopy(target)
+        new_target.name = f"{new_target.name}_rerun"
+        return new_target
 
 
 def maybe_get_message(
@@ -31,29 +47,23 @@ def maybe_get_message(
 @dataclass
 class PyGraph:
     """
-    Graph that simply sorts commands by their target type
+    PyGraph is the python wrapper for the otl runtime.
     """
 
     otl_targets: Optional[Dict[str, Target]]
-    commands: Dict[OtlTargetType, List[Command]]
+    """ 
+    holds the original otl targets (the python rules) that the user supplied. 
+
+    This is used to re-generate new commands on failure
+    """
+    commands: Dict[str, List[Command]]
+    """ 
+    holds all of the commands that are live in the graph
+    """
     controller: PyController
     listener: PySubscriber
     done_tracker = IsDoneSubscriber()
-
-    def get_test_type(self, tt: OtlTargetType) -> List[Command]:
-        return self.commands[tt]
-
-    @property
-    def build(self):
-        return self.get_test_type(OtlTargetType.Build)
-
-    @property
-    def test(self):
-        return self.get_test_type(OtlTargetType.Test)
-
-    @property
-    def stimulus(self):
-        return self.get_test_type(OtlTargetType.Stimulus)
+    retcode_tacker = RetcodeTracker()
 
     def runloop(self):
         with OutputConsole() as console:
@@ -63,46 +73,90 @@ class PyGraph:
                 message = maybe_get_message(self.listener, blocking=False)
                 if message:
                     self.done_tracker.process_message(message)
+                    self.retcode_tacker.process_message(message)
                     console.process_message(message)
                 if not message:
                     # add a little bit of backoff
                     time.sleep(0.01)
 
-    def run_one_test(self, name: str):
+    def reset(self):
         self.done_tracker.reset()
+        self.retcode_tacker.reset()
+
+    def run_one_test(self, name: str):
+        self.reset()
         self.controller.run_one_test(name)
         self.runloop()
 
-    def run_all_tests(self, maybe_type: str):
-        self.done_tracker.reset()
-        handle = self.controller.run_all_tests(maybe_type)
+    def run_specific_commands(self, commands: List[Command]):
+        self.reset()
+        test_names = [command.name for command in commands]
+        self.controller.run_many_tests(test_names)
         self.runloop()
 
-    def get_all_tests_as_scripts(self) -> List[Tuple[str, List[str]]]:
-        """
-        returns test name and script
-        """
-        return [
-            (command.name, command.script)
-            for command in self.commands[OtlTargetType.Test]
-        ]
+    def run_all_tests(self, maybe_type: str):
+        self.reset()
+        self.controller.run_all_tests(maybe_type)
+        self.runloop()
+
+    def rerun(
+        self,
+        rerun_callback: Callable[
+            [Target, int], Optional[Target]
+        ] = default_target_rerun_callback,
+    ):
+        if self.otl_targets:
+            new_targets = [
+                rerun_callback(self.otl_targets[target], retcode)
+                for target, retcode in self.retcode_tacker.retcode.items()
+            ]
+
+            filtered_targets = [target for target in new_targets if target]
+            for target in filtered_targets:
+                self.otl_targets[target.name] = target
+            # TODO: its likely that we will also need to handle regenerating dependencies
+            #       for a first pass functionality, lets ignore this for now
+            command_list = lower_target_to_command(filtered_targets)
+            self.add_commands(command_list)
+            self.run_specific_commands(command_list)
+        else:
+            print(
+                "Warning! Cannot auto re-run because no otl targets have been provided"
+            )
+
+    def add_commands(self, commands: List[Command]):
+        for command in commands:
+            self.commands[command.target_type].append(command)
+
+        commands_as_str = yaml.safe_dump([command.to_dict() for command in commands])
+        self.controller.set_graph(commands_as_str)
 
     @classmethod
     def init(cls, otl_targets: Dict[str, Target], commands: List[Command]):
         rv = {}
         for tar_typ in OtlTargetType:
             rv[tar_typ.value] = []
+
+        for tar_typ in OtlTargetType:
+            rv[tar_typ.value] = []
         for command in commands:
             rv[command.target_type].append(command)
 
-        commands_as_str = yaml.safe_dump([command.to_dict() for command in commands])
         graph = PyController()
-        graph.set_graph(commands_as_str)
+
         listener = graph.add_py_listener()
-        return cls(
+        rv = cls(
             otl_targets=otl_targets, commands=rv, controller=graph, listener=listener
         )
+        rv.add_commands(commands)
+        return rv
 
+    # This is a testing utility
     @classmethod
     def init_commands_only(cls, commands: List[Command]):
         return cls.init({}, commands)
+
+
+def create_graph(otl_test_list: str) -> PyGraph:
+    targets, command_list = parse_otl(otl_test_list)
+    return PyGraph.init(targets, command_list)

--- a/py-otl/pyotl/subscribers/output_collector.py
+++ b/py-otl/pyotl/subscribers/output_collector.py
@@ -17,7 +17,6 @@ from rich.progress import (
     TaskID,
     TimeElapsedColumn,
 )
-import time
 
 
 class Status(enum.Enum):
@@ -105,7 +104,7 @@ class OutputConsole:
 
             # we are processing stdout of a command
             else:
-                if self.print_stdout:
+                if self.progress and self.print_stdout:
                     self.progress.print(payload.output)
 
     def processed_started(self):

--- a/py-otl/pyotl/subscribers/retcode.py
+++ b/py-otl/pyotl/subscribers/retcode.py
@@ -1,0 +1,34 @@
+from dataclasses import dataclass, field
+from typing import Dict, cast
+import betterproto
+from pyotl.otl_telemetry.data import CommandEvent, CommandFinished, Event
+
+
+@dataclass
+class RetcodeTracker:
+    """
+    Simple subscriber that maps commands to return codes
+    """
+
+    retcode: Dict[str, int] = field(default_factory=dict)
+
+    def process_message(self, message: Event):
+        (variant, event_payload) = betterproto.which_one_of(message, "et")
+        if variant == "command":
+            event_payload = cast(CommandEvent, event_payload)
+            (command_name, command_payload) = betterproto.which_one_of(
+                event_payload, "CommandVariant"
+            )
+
+            if command_name == "finished":
+                command_payload = cast(CommandFinished, command_payload)
+                self.retcode[event_payload.command_ref] = (
+                    command_payload.out.status_code
+                )
+            else:
+                pass
+        else:
+            pass
+
+    def reset(self):
+        self.retcode = {}

--- a/py-otl/src/lib.rs
+++ b/py-otl/src/lib.rs
@@ -109,6 +109,14 @@ impl PyController {
         Ok(())
     }
 
+    pub fn run_many_tests(&self, tests: Vec<String>) -> PyResult<()> {
+        self.handle
+            .tx_client
+            .send(ClientCommand::execute_many(tests))
+            .map_err(client_channel_err)?;
+        Ok(())
+    }
+
     pub fn add_py_listener(&self) -> PyResult<PySubscriber> {
         let (sub, fwder) = PySubscriber::create_subscriber(self.handle.tx_client.clone());
         self.handle

--- a/pytests/test_graphs_simple.py
+++ b/pytests/test_graphs_simple.py
@@ -1,4 +1,4 @@
-from pyotl.pygraph import PyGraph
+from pyotl.pygraph import PyGraph, create_graph
 from pyotl.path_utils import get_git_root
 from pyotl.interfaces import Command
 import yaml
@@ -13,4 +13,11 @@ def test_sanity_pygraph():
     graph.run_all_tests("test")
 
 
-test_sanity_pygraph()
+def test_sanity_pygraph_rerun():
+    test_list = f"{get_git_root()}/examples/tests_only.otl"
+    graph = create_graph(test_list)
+    graph.run_all_tests("test")
+    graph.rerun()
+
+
+test_sanity_pygraph_rerun()


### PR DESCRIPTION
this mr adds in re-running -- it is a primitive scheme with this MR, because I didn't want to commit to the "mechanics" of how new targets are created. 

with this commit we added in: 

-  a re-run mechanisms to create new commands
    -  for each command that finished executing in the graph, we execute a callback that takes in the target and it's return code,  returns the "new" target that should be executed. 
    - Currently, the callback logic is naive; **it will create a new command for every test target that completed named ${ORIG_COMMAND_NAME}_rerun, with the exact same bash script**. 
    - i'm going to experiment with how "debug bash script" generation feels and make another PR with those changes on top -- that should be a small amount of code, but it's an important interface we'll expose to users 
-  small rust changes for a `run_many` tests convience method (currently we only had run one test or a class of tests)
