### PR TITLE
fix running one test

### DIFF
--- a/.github/workflows/postcommit.yml
+++ b/.github/workflows/postcommit.yml
@@ -39,13 +39,6 @@ jobs:
       - uses: Swatinem/rust-cache@v1
         with:
           key: "1"
-      - name: Build wheels
-        uses: PyO3/maturin-action@v1
-        with:
-          target: ${{ matrix.target }}
-          args: --out dist --manifest-path py-smelt/Cargo.toml -i python3.10
-          sccache: "true"
-          manylinux: auto
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -56,7 +49,7 @@ jobs:
         shell: bash
         run: |
           set -e
-          pip install pysmelt --find-links dist --force-reinstall
+          cd py-smelt && pip install -e . -v && cd -
           pip install pytest
           cd pytests && pytest .
 

--- a/crates/smelt-graph/src/executor/common.rs
+++ b/crates/smelt-graph/src/executor/common.rs
@@ -4,10 +4,10 @@ use std::path::PathBuf;
 use crate::Command;
 
 use dice::DiceData;
-use smelt_core::{CommandDefPath, SmeltErr};
+
 use smelt_data::{
     executed_tests::{ArtifactPointer, ExecutedTestResult, TestResult},
-    Event, SmeltError,
+    Event,
 };
 
 use smelt_events::runtime_support::GetCmdDefPath;

--- a/crates/smelt-graph/src/executor/docker.rs
+++ b/crates/smelt-graph/src/executor/docker.rs
@@ -5,8 +5,7 @@ use dice::{DiceData, UserComputationData};
 use futures::StreamExt;
 
 use smelt_data::{
-    executed_tests::{ExecutedTestResult, TestResult},
-    CommandOutput, Event,
+    executed_tests::{ExecutedTestResult}, Event,
 };
 
 use smelt_events::runtime_support::{GetSmeltRoot, GetTraceId, GetTxChannel};

--- a/crates/smelt-graph/src/executor/local.rs
+++ b/crates/smelt-graph/src/executor/local.rs
@@ -7,7 +7,7 @@ use crate::Command;
 use async_trait::async_trait;
 
 use smelt_data::{
-    executed_tests::{ExecutedTestResult, TestResult},
+    executed_tests::{ExecutedTestResult},
     CommandOutput, Event,
 };
 use smelt_events::{

--- a/crates/smelt-graph/src/executor/mod.rs
+++ b/crates/smelt-graph/src/executor/mod.rs
@@ -4,8 +4,7 @@ use crate::Command;
 use dice::{DiceData, DiceDataBuilder, UserComputationData};
 
 use smelt_data::{
-    executed_tests::{ExecutedTestResult, TestResult},
-    Event,
+    executed_tests::{ExecutedTestResult},
 };
 
 mod common;

--- a/crates/smelt-graph/src/graph.rs
+++ b/crates/smelt-graph/src/graph.rs
@@ -371,9 +371,17 @@ impl CommandGraph {
             }) = self.rx_chan.recv().await
             {
                 let rv = self
-                    .eat_command(command, event_streamer)
+                    .eat_command(command, event_streamer.clone())
                     .await
                     .map_err(|err| err.to_string());
+                if let Err(ref err) = rv {
+                    event_streamer
+                        .send(Event::runtime_error(
+                            err.clone(),
+                            "ADD_TRACE_ID_HERE".to_string(),
+                        ))
+                        .await;
+                }
                 let _ = oneshot_confirmer.send(rv);
             }
         }

--- a/py-smelt/pysmelt/pygraph.py
+++ b/py-smelt/pysmelt/pygraph.py
@@ -61,8 +61,6 @@ def maybe_get_message(
     listener: PyEventStream, blocking: bool = False
 ) -> Optional[Event]:
     try: 
-        if listener.is_done():
-            return None
         if blocking:
             message = listener.pop_message_blocking()
             event = Event.FromString(message)
@@ -133,7 +131,6 @@ class PyGraph:
                 # but async interopt with rust is kind of experimental and i dont want to do it yet
                 message = maybe_get_message(listener, blocking=False)
                 if message:
-                    
                     self.retcode_tracker.process_message(message)
                     console.process_message(message)
                     errhandler.process_message(message)

--- a/py-smelt/src/lib.rs
+++ b/py-smelt/src/lib.rs
@@ -36,7 +36,6 @@ pub struct PyController {
 pub struct PyEventStream {
     recv_chan: Receiver<Event>,
     done: bool,
-    exhausted: bool,
 }
 
 impl PyEventStream {
@@ -44,7 +43,6 @@ impl PyEventStream {
         Self {
             recv_chan,
             done: false,
-            exhausted: false,
         }
     }
 }
@@ -144,7 +142,7 @@ impl PyEventStream {
         }
     }
 
-    pub fn is_done<'py>(&mut self, _py: Python<'py>) -> bool {
+    pub fn is_done(&mut self, _py: Python<'_>) -> bool {
         self.done
     }
 }

--- a/py-smelt/src/lib.rs
+++ b/py-smelt/src/lib.rs
@@ -36,7 +36,6 @@ pub struct PyController {
 pub struct PyEventStream {
     recv_chan: Receiver<Event>,
     done: bool,
-    chan_exhausted: bool,
 }
 
 impl PyEventStream {
@@ -44,7 +43,6 @@ impl PyEventStream {
         Self {
             recv_chan,
             done: false,
-            chan_exhausted: false,
         }
     }
 }

--- a/py-smelt/src/lib.rs
+++ b/py-smelt/src/lib.rs
@@ -36,6 +36,7 @@ pub struct PyController {
 pub struct PyEventStream {
     recv_chan: Receiver<Event>,
     done: bool,
+    chan_exhausted: bool,
 }
 
 impl PyEventStream {
@@ -43,6 +44,7 @@ impl PyEventStream {
         Self {
             recv_chan,
             done: false,
+            chan_exhausted: false,
         }
     }
 }
@@ -143,7 +145,7 @@ impl PyEventStream {
     }
 
     pub fn is_done(&mut self, _py: Python<'_>) -> bool {
-        self.done
+        self.done && self.recv_chan.is_closed()
     }
 }
 

--- a/pytests/test_graphs_simple.py
+++ b/pytests/test_graphs_simple.py
@@ -98,3 +98,7 @@ def test_sanity_pygraph_docker(simple_docker_image):
     assert (
         passed_commands == expected_passed
     ), f"Expected to see {expected_passed} tasks passed, saw {passed_commands} tests"
+
+
+for i in range(10):
+    test_sanity_pygraph_runone()

--- a/pytests/test_graphs_simple.py
+++ b/pytests/test_graphs_simple.py
@@ -40,6 +40,17 @@ def test_sanity_pygraph_rerun_nofailing():
     assert observed_reexec == expected_executed_tasks, f"We don't re-run"
 
 
+def test_sanity_pygraph_runone():
+    """
+    Tests running one test -- we didn't have this path tested, woops
+    """
+    test_list = f"{get_git_root()}/test_data/smelt_files/tests_only.smelt.yaml"
+    graph = create_graph(test_list)
+
+    graph.run_one_test_interactive("test_example_1")
+    # we have 3 tests, 0 of which fail -- so we should rerun no tests
+
+
 def test_sanity_pygraph_rerun_with_failing():
     test_list = f"{get_git_root()}/test_data/smelt_files/failing_tests_only.smelt.yaml"
     graph = create_graph(test_list)


### PR DESCRIPTION
some fixes for the run one api -- because we made lifetime changes to listener in a previous commit, this path was broken.

Prior to https://github.com/silogy-io/smelt/pull/23, we assumed that life of a listener was decoupled from a `is_done()` message -- and this was true, because there was some global scope. 

Now that listeners are scoped to the lifetime of an execution, we know that a stream is successfully "completed" when:

* the channel has closed
* and we've seen a done message
 