### PR TITLE
add scaffolding for sync client responses

### DIFF
--- a/crates/smelt-data/client.data.proto
+++ b/crates/smelt-data/client.data.proto
@@ -10,6 +10,7 @@ message ClientCommand {
     RunOne runone = 2;
     RunType runtype = 3;
     RunMany runmany = 4;
+    GetConfig getcfg = 5;
   }
 }
 
@@ -21,6 +22,19 @@ message RunType {
   // not today babey
   string typeinfo = 1;
 }
+message GetConfig {};
+
+
+// Responses to the client command
+message ClientResp {
+  oneof ClientResponses {
+    ConfigureSmelt current_cfg = 1;
+  }
+}
+
+
+
+
 
 // This configuration is done once, when SMELT is initialized
 // The client should provide this when creating an smelt handle

--- a/crates/smelt-data/src/client_commands.rs
+++ b/crates/smelt-data/src/client_commands.rs
@@ -36,4 +36,12 @@ impl ClientCommand {
             client_commands: Some(cc),
         }
     }
+
+    pub fn get_cfg() -> Self {
+        let cc = ClientCommands::Getcfg(GetConfig {});
+
+        ClientCommand {
+            client_commands: Some(cc),
+        }
+    }
 }

--- a/crates/smelt-events/src/lib.rs
+++ b/crates/smelt-events/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod runtime_support;
 
+use smelt_data::client_commands::{client_resp::ClientResponses, ClientResp};
 pub use smelt_data::{client_commands::ClientCommand, Event};
 
 use tokio::{
@@ -59,7 +60,7 @@ mod helpers {
     }
 }
 
-pub type ClientCommandResp = Result<(), String>;
+pub type ClientCommandResp = Result<ClientResp, String>;
 
 pub struct ClientCommandBundle {
     pub message: ClientCommand,

--- a/crates/smelt-graph/src/executor/common.rs
+++ b/crates/smelt-graph/src/executor/common.rs
@@ -1,5 +1,5 @@
-use std::io::Write;
 use std::path::PathBuf;
+use std::{io::Write, path::Path};
 
 use crate::Command;
 

--- a/crates/smelt-graph/src/executor/docker.rs
+++ b/crates/smelt-graph/src/executor/docker.rs
@@ -4,9 +4,7 @@ use async_trait::async_trait;
 use dice::{DiceData, UserComputationData};
 use futures::StreamExt;
 
-use smelt_data::{
-    executed_tests::{ExecutedTestResult}, Event,
-};
+use smelt_data::{executed_tests::ExecutedTestResult, Event};
 
 use smelt_events::runtime_support::{GetSmeltRoot, GetTraceId, GetTxChannel};
 use std::{collections::HashMap, sync::Arc};
@@ -79,7 +77,7 @@ impl Executor for DockerExecutor {
             .iter()
             .fold(base_binds, |mut val, b| {
                 val.push(format!("{}:{}", b.0, b.1));
-                dbg!(&val);
+
                 val
             });
 

--- a/py-smelt/pysmelt/path_utils.py
+++ b/py-smelt/pysmelt/path_utils.py
@@ -36,4 +36,5 @@ def relatavize_inp_path(smelt_root: str, inp_path: str) -> SmeltPath:
     abs_inp_path = os.path.abspath(inp_path)
 
     # Return the path of `abs_inp_path` relative to `abs_path`
-    return SmeltPath.from_str(os.path.relpath(abs_inp_path, smelt_root))
+    rv = SmeltPath.from_str(os.path.relpath(abs_inp_path, smelt_root))
+    return rv

--- a/py-smelt/pysmelt/pygraph.py
+++ b/py-smelt/pysmelt/pygraph.py
@@ -37,8 +37,6 @@ def default_cfg(cmd_path: SmeltPath) -> ConfigureSmelt:
     rv.smelt_root = rc.smelt_root
     rv.command_def_path = cmd_path.as_str
     rv.local = CfgLocal()
-    
-
     return rv
 
 
@@ -76,7 +74,7 @@ def maybe_get_message(
         """
         In expectation, we only return an error if the channel has been closed  
 
-        We don't have any paths above this function to handle that error, so we'll handle it here as getting the message failing 
+        We don't have any paths above this function to handle that error, so we'll handle it here
         """
         
         print(e)
@@ -170,6 +168,9 @@ class PyGraph:
             if not message:
                 # add a little bit of backoff
                 yield listener.is_done()
+    def get_current_cfg(self) -> ConfigureSmelt:
+        raw_cfg = self.controller.get_current_cfg() 
+        return ConfigureSmelt.FromString(raw_cfg)
 
     def reset(self):
         pass

--- a/py-smelt/src/lib.rs
+++ b/py-smelt/src/lib.rs
@@ -1,5 +1,5 @@
 use smelt_core::SmeltErr;
-use smelt_data::client_commands::ClientCommand;
+use smelt_data::client_commands::{client_resp::ClientResponses, ClientCommand, ClientResp};
 use smelt_data::{client_commands::ConfigureSmelt, Event};
 
 use prost::Message;
@@ -51,9 +51,11 @@ fn client_channel_err(_in_err: impl std::error::Error) -> PyErr {
     PyRuntimeError::new_err("Channel error trying to send a command to the client")
 }
 
-fn handle_client_resp(resp: Result<ClientCommandResp, impl std::error::Error>) -> PyResult<()> {
+fn handle_client_resp(
+    resp: Result<ClientCommandResp, impl std::error::Error>,
+) -> PyResult<ClientResp> {
     match resp {
-        Ok(Ok(())) => Ok(()),
+        Ok(Ok(client_resp)) => Ok(client_resp),
         Ok(Err(str)) => Err(PyRuntimeError::new_err(format!(
             "Client command failed with error {str}"
         ))),
@@ -88,7 +90,7 @@ impl PyController {
             submit_message(&self.handle.tx_client, ClientCommand::send_graph(graph))?;
 
         let resp = sync_chan.blocking_recv();
-        handle_client_resp(resp)
+        handle_client_resp(resp).map(|_| ())
     }
 
     pub fn run_all_tests(&self, tt: String) -> PyResult<PyEventStream> {
@@ -102,6 +104,17 @@ impl PyController {
     pub fn run_many_tests(&self, tests: Vec<String>) -> PyResult<PyEventStream> {
         self.run_tests(ClientCommand::execute_many(tests))
     }
+
+    pub fn get_current_cfg<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
+        let command = ClientCommand::get_cfg();
+        let EventStreams { sync_chan, .. } =
+            submit_message(&self.handle.tx_client, command).map_err(client_channel_err)?;
+        let resp = sync_chan.blocking_recv();
+        handle_client_resp(resp).map(|val| match val.client_responses.unwrap() {
+            ClientResponses::CurrentCfg(a) => to_bytes(a, py),
+            _ => unreachable!("Incorrect response coming from the server for get_current_cfg"),
+        })
+    }
 }
 
 impl PyController {
@@ -111,6 +124,14 @@ impl PyController {
         Ok(PyEventStream::create_subscriber(event_stream))
     }
 }
+
+#[inline]
+fn to_bytes<'py, M: Message>(message: M, py: Python<'py>) -> Bound<'py, PyBytes> {
+    let val = message.encode_to_vec();
+
+    PyBytes::new_bound(py, &val)
+}
+
 #[pymethods]
 impl PyEventStream {
     pub fn pop_message_blocking<'py>(&mut self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
@@ -142,6 +163,8 @@ impl PyEventStream {
         }
     }
 
+    /// Returns true if we've seen a entire Invocation complete end to end AND the channel has
+    /// been closed
     pub fn is_done(&mut self, _py: Python<'_>) -> bool {
         self.done && self.recv_chan.is_closed()
     }

--- a/pytests/test_graphs_simple.py
+++ b/pytests/test_graphs_simple.py
@@ -30,6 +30,16 @@ def test_sanity_pygraph():
     graph.run_all_tests("test")
 
 
+def test_get_cfg():
+
+    cmd_def_path_in = "test_data/smelt_files/large_profile.smelt.yaml"
+    test_list = f"{get_git_root()}/test_data/smelt_files/large_profile.smelt.yaml"
+    graph = create_graph(test_list)
+    assert (
+        cmd_def_path_in == graph.get_current_cfg().command_def_path
+    ), "command_def_path roundtrip doesn't match"
+
+
 def test_sanity_pygraph_rerun_nofailing():
     """
     Tests the case where no re-run is needed
@@ -150,6 +160,3 @@ def test_profiler():
     # assert (
     #    mem_used_ratio > lower_bound
     # ), "We expect that the more memory test takes about ~4x more memory than the baseline -- we set a lower bound of 2.5x mem to be safe"
-
-
-test_profiler()


### PR DESCRIPTION
these changes enable:
*  round trip sync client commands to contain data -- before, the server wouldn't send any response
* adds a `get_cfg()` command and function -- we can now get cfg data out from the server easily