### PR TITLE
Rerun2

### DIFF
--- a/crates/smelt-data/src/executed_tests.rs
+++ b/crates/smelt-data/src/executed_tests.rs
@@ -28,6 +28,11 @@ impl ExecutedTestResult {
     pub fn is_skipped(&self) -> bool {
         matches!(self, Self::Skipped)
     }
+
+    pub fn test_name(&self) -> String {
+        self.clone().to_test_result().test_name
+    }
+
     pub fn to_test_result(self) -> TestResult {
         match self {
             Self::Success(val) => val,
@@ -49,6 +54,20 @@ impl ExecutedTestResult {
                 );
                 -1
             }
+        }
+    }
+    pub fn failed(&self) -> bool {
+        match self {
+            Self::Success(val) => val.outputs.as_ref().map(|val| val.exit_code).unwrap() != 0,
+            Self::MissingFiles { test_result, .. } => {
+                test_result
+                    .outputs
+                    .as_ref()
+                    .map(|val| val.exit_code)
+                    .unwrap()
+                    != 0
+            }
+            Self::Skipped => false,
         }
     }
 }

--- a/crates/smelt-data/src/lib.rs
+++ b/crates/smelt-data/src/lib.rs
@@ -60,7 +60,7 @@ pub mod smelt_telemetry {
 
     tonic::include_proto!("smelt_telemetry");
 }
-use executed_tests::{TestOutputs, TestResult};
+use executed_tests::{TestResult};
 pub use smelt_telemetry::*;
 
 impl Event {

--- a/crates/smelt-events/src/runtime_support.rs
+++ b/crates/smelt-events/src/runtime_support.rs
@@ -1,9 +1,9 @@
-use std::path::{Path, PathBuf};
+use std::path::{PathBuf};
 
 use crate::Event;
 use async_trait::async_trait;
 use dice::{DiceData, DiceDataBuilder, UserComputationData};
-use smelt_core::SmeltPath;
+
 use smelt_data::client_commands::ConfigureSmelt;
 use tokio::sync::{Semaphore, SemaphorePermit};
 use uuid::Uuid;
@@ -127,12 +127,12 @@ impl LockSemaphore for DiceData {
 
         let available = sem.available_permits();
         tracing::debug!("Acquiring semaphore {cnt}, max is {max_slots}, current is {available}");
-        let val = sem
+        
+
+        sem
             .acquire_many(slots)
             .await
-            .expect("We should NEVER close this semaphore");
-
-        val
+            .expect("We should NEVER close this semaphore")
     }
 }
 

--- a/crates/smelt-graph/src/commands.rs
+++ b/crates/smelt-graph/src/commands.rs
@@ -44,6 +44,8 @@ pub struct Command {
     pub runtime: Runtime,
     #[serde(default)]
     pub working_dir: PathBuf,
+    #[serde(default)]
+    pub on_failure: PathBuf,
 }
 
 impl Command {
@@ -85,11 +87,7 @@ impl Command {
     }
 
     pub fn script_contents(&self) -> impl Iterator<Item = String> + '_ {
-        self.runtime
-            .env
-            .iter()
-            .map(|(env_name, env_val)| format!("export {}={}", env_name, env_val))
-            .chain(self.script.iter().cloned())
+        self.script.iter().cloned()
     }
 }
 
@@ -99,6 +97,8 @@ pub enum TargetType {
     Test,
     Stimulus,
     Build,
+    Rerun,
+    Rebuild,
 }
 
 impl FromStr for TargetType {
@@ -109,6 +109,8 @@ impl FromStr for TargetType {
             "test" => Ok(TargetType::Test),
             "stimulus" => Ok(TargetType::Stimulus),
             "build" => Ok(TargetType::Build),
+            "rebuild" => Ok(TargetType::Rebuild),
+            "rerun" => Ok(TargetType::Rerun),
             _ => Err(SmeltErr::BadTargetType(s.to_string())),
         }
     }
@@ -119,9 +121,6 @@ pub struct Runtime {
     pub num_cpus: u32,
     pub max_memory_mb: u32,
     pub timeout: u32,
-    pub env: std::collections::BTreeMap<String, String>,
-    #[serde(default)]
-    pub command_run_dir: Option<String>,
 }
 
 impl fmt::Display for Command {
@@ -140,6 +139,8 @@ impl fmt::Display for TargetType {
                 TargetType::Test => "test",
                 TargetType::Stimulus => "stimulus",
                 TargetType::Build => "build",
+                TargetType::Rerun => "rerun",
+                TargetType::Rebuild => "rebuild",
             }
         )
     }
@@ -149,8 +150,8 @@ impl fmt::Display for Runtime {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "Runtime {{ num_cpus: {}, max_memory_mb: {}, timeout: {}, env: {:?} }}",
-            self.num_cpus, self.max_memory_mb, self.timeout, self.env
+            "Runtime {{ num_cpus: {}, max_memory_mb: {}, timeout: {}, }}",
+            self.num_cpus, self.max_memory_mb, self.timeout
         )
     }
 }

--- a/crates/smelt-graph/src/commands.rs
+++ b/crates/smelt-graph/src/commands.rs
@@ -45,7 +45,7 @@ pub struct Command {
     #[serde(default)]
     pub working_dir: PathBuf,
     #[serde(default)]
-    pub on_failure: PathBuf,
+    pub on_failure: Option<CommandDependency>,
 }
 
 impl Command {

--- a/crates/smelt-graph/src/executor/common.rs
+++ b/crates/smelt-graph/src/executor/common.rs
@@ -100,7 +100,7 @@ pub(crate) fn create_test_result(
         //TODO: smelt-out shouldn't be hardcoded here, sorry for sinning mom
         pointer: Some(Pointer::Path(format!(
             "{}/smelt-out/{}/command.out",
-            smelt_root.to_string_lossy().to_string(),
+            smelt_root.to_string_lossy(),
             command.name,
         ))),
     }];

--- a/crates/smelt-graph/src/executor/common.rs
+++ b/crates/smelt-graph/src/executor/common.rs
@@ -32,7 +32,7 @@ pub(crate) async fn prepare_workspace(
 ) -> anyhow::Result<Workspace> {
     // TODO -- maybe parameterize?
     let smeltoutdir = "smelt-out";
-    let env = &command.runtime.env;
+
     let working_dir = command.default_target_root(smelt_root.as_path())?;
     let script_file = working_dir.join(Command::script_file());
     let stdout_file = working_dir.join(Command::stdout_file());
@@ -52,10 +52,6 @@ pub(crate) async fn prepare_workspace(
         smeltoutdir,
         command.name
     );
-
-    for (env_name, env_val) in env.iter() {
-        writeln!(buf, "export {}={}", env_name, env_val)?;
-    }
 
     writeln!(buf, "cd {}", command_working_dir.to_string_lossy());
 

--- a/py-smelt/pysmelt/default_targets.py
+++ b/py-smelt/pysmelt/default_targets.py
@@ -33,7 +33,7 @@ class raw_bash(Target):
         return self.debug_cmds
 
     def gen_rebuild_script(self) -> Optional[List[str]]:
-        return self.debug_cmds
+        return self.rebuild_cmds
 
     def get_dependencies(self) -> List[TargetRef]:
         return self.deps

--- a/py-smelt/pysmelt/default_targets.py
+++ b/py-smelt/pysmelt/default_targets.py
@@ -20,10 +20,8 @@ class raw_bash(Target):
     outputs: Dict[str, str] = field(default_factory=dict)
 
     def gen_script(self) -> List[str]:
-        if "debug" in self.injected_state and self.debug_cmds:
-            return self.debug_cmds
-        else:
-            return self.cmds
+
+        return self.cmds
 
     def get_dependencies(self) -> List[TargetRef]:
         return self.deps

--- a/py-smelt/pysmelt/default_targets.py
+++ b/py-smelt/pysmelt/default_targets.py
@@ -1,7 +1,10 @@
 from dataclasses import dataclass, field
 from functools import partial
 from pysmelt.interfaces import Target, SmeltFilePath, SmeltTargetType, TargetRef
-from typing import Any, List, Dict
+from typing import Any, List, Dict, Optional
+
+from pysmelt.interfaces.runtime import RuntimeRequirements
+from pysmelt.interfaces.target import CGVar
 
 
 @dataclass
@@ -15,19 +18,40 @@ class raw_bash(Target):
     """
 
     cmds: List[str] = field(default_factory=list)
-    debug_cmds: List[str] = field(default_factory=list)
     deps: List[TargetRef] = field(default_factory=list)
     outputs: Dict[str, str] = field(default_factory=dict)
+    debug_cmds: Optional[List[str]] = None
+    rebuild_cmds: Optional[List[str]] = None
+    num_cpus: Optional[int] = None
+    timeout: Optional[int] = None
+    mem_usage: Optional[int] = None
 
     def gen_script(self) -> List[str]:
-
         return self.cmds
+
+    def gen_rerun_script(self) -> Optional[List[str]]:
+        return self.debug_cmds
+
+    def gen_rebuild_script(self) -> Optional[List[str]]:
+        return self.debug_cmds
 
     def get_dependencies(self) -> List[TargetRef]:
         return self.deps
 
-    def get_outputs(self) -> Dict[str, str]:
+    def get_outputs(
+        self,
+    ) -> Dict[str, str]:
         return self.outputs
+
+    def runtime_requirements(
+        self,
+    ) -> RuntimeRequirements:
+        rr = RuntimeRequirements.default()
+        if self.num_cpus:
+            rr.num_cpus = self.num_cpus
+        if self.timeout:
+            rr.timeout = self.timeout
+        return rr
 
 
 @dataclass

--- a/py-smelt/pysmelt/interfaces/command.py
+++ b/py-smelt/pysmelt/interfaces/command.py
@@ -1,8 +1,8 @@
-from typing import List, Literal, Dict, Any
+from typing import List, Literal, Dict, Any, Optional, Tuple
 from enum import Enum
 from pysmelt.interfaces.paths import SmeltPath, TempTarget
 from pysmelt.interfaces.runtime import RuntimeRequirements
-from pysmelt.interfaces.target import SmeltTargetType, Target
+from pysmelt.interfaces.target import CGVar, SmeltTargetType, Target
 from dataclasses import dataclass, asdict
 
 
@@ -10,7 +10,8 @@ from pysmelt.rc import SmeltRcHolder
 
 CommandRef = str
 
-CommandLiterals = Literal["test", "stimulus", "build"]
+# TODO: make this automatic from the targettype enum
+CommandType = Literal["test", "stimulus", "build", "rebuild", "rerun"]
 
 
 @dataclass
@@ -22,7 +23,7 @@ class Command:
     """
 
     name: str
-    target_type: Literal["test", "stimulus", "build"]
+    target_type: CommandType
     script: List[str]
     """
     A list of bash commands that will be executed in sequence
@@ -38,9 +39,12 @@ class Command:
     outputs: List[str]
     runtime: RuntimeRequirements
     working_dir: str
+    on_failure: Optional[CommandRef] = None
 
     @classmethod
-    def from_target(cls, target: Target, working_dir: str):
+    def from_target(
+        cls, target: Target, working_dir: str
+    ) -> Tuple["Command", Optional["Command"], Optional["Command"]]:
         name = target.name
         target_type = target.rule_type().value
         script = target.gen_script()
@@ -48,9 +52,11 @@ class Command:
         dependencies = target.get_dependencies()
         dependent_files = target.get_dependent_files()
 
+        rerun_script = target.gen_rerun_script()
+        rebuild_script = target.gen_rebuild_script()
         outputs = list(map(lambda path: str(path), target.get_outputs().values()))
 
-        return cls(
+        base_target = cls(
             name=name,
             target_type=target_type,
             script=script,
@@ -59,7 +65,43 @@ class Command:
             dependent_files=dependent_files,
             outputs=outputs,
             working_dir=working_dir,
+            on_failure=f"{name}@rerun" if rerun_script else None,
         )
+        rebuild_target = None
+        rerun_target = None
+
+        if rebuild_script:
+            rebuild_target = cls(
+                name=f"{name}@rebuild",
+                target_type=SmeltTargetType.Rebuild.value,
+                script=rebuild_script,
+                runtime=target.runtime_requirements(CGVar.rebuild),
+                dependencies=dependencies,
+                dependent_files=target.get_dependent_files(CGVar.rebuild),
+                outputs=list(
+                    map(
+                        lambda path: str(path), target.get_outputs(CGVar.rerun).values()
+                    )
+                ),
+                working_dir=working_dir,
+            )
+
+        if rerun_script:
+            rerun_target = cls(
+                name=f"{name}@rerun",
+                target_type=SmeltTargetType.Rerun.value,
+                script=rerun_script,
+                runtime=target.runtime_requirements(CGVar.rerun),
+                dependencies=dependencies,
+                dependent_files=target.get_dependent_files(CGVar.rerun),
+                outputs=list(
+                    map(
+                        lambda path: str(path), target.get_outputs(CGVar.rerun).values()
+                    )
+                ),
+                working_dir=working_dir,
+            )
+        return base_target, rebuild_target, rerun_target
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]):

--- a/py-smelt/pysmelt/interfaces/procedural.py
+++ b/py-smelt/pysmelt/interfaces/procedural.py
@@ -17,7 +17,7 @@ def import_as_target(target_path: str) -> Target:
     if tt.file_path not in ImportTracker.imported_commands:
         targets, commands = parse_smelt(tt.file_path)
         ImportTracker.imported_commands[tt.file_path] = commands
-    if chosen_name not in targets:
-        raise RuntimeError(f"Could not find command {target_path}")
+        if chosen_name not in targets:
+            raise RuntimeError(f"Could not find command {target_path}")
     dec_import_depth()
     return ImportTracker.imported_targets[tt.file_path][chosen_name]

--- a/py-smelt/pysmelt/interfaces/procedural.py
+++ b/py-smelt/pysmelt/interfaces/procedural.py
@@ -4,17 +4,21 @@ from pysmelt.generators.procedural import dec_import_depth, inc_import_depth
 from pysmelt.interfaces.command import Command
 from pysmelt.interfaces.paths import SmeltPath, TempTarget
 from pysmelt.interfaces.target import Target
-from pysmelt.smelt_muncher import ImportTracker, parse_smelt
+from pysmelt.smelt_muncher import parse_smelt
+from pysmelt.tracker import ImportTracker
 
 
 def import_as_target(target_path: str) -> Target:
     inc_import_depth()
-    tt = TempTarget.parse_string_smelt_target(target_path)
-    tt.file_path.to_abs_path()
+    tt = TempTarget.parse_string_smelt_target(
+        target_path, ImportTracker.local_file_alias().path
+    )
     chosen_name = tt.name
-    targets, commands = parse_smelt(tt.file_path)
-    ImportTracker.imported_commands[tt.file_path] = commands
+    if tt.file_path not in ImportTracker.imported_commands:
+        targets, commands = parse_smelt(tt.file_path)
+        ImportTracker.imported_commands[tt.file_path] = commands
+        ImportTracker.imported_targets[tt.file_path] = targets
     if chosen_name not in targets:
         raise RuntimeError(f"Could not find command {target_path}")
     dec_import_depth()
-    return targets[chosen_name]
+    return ImportTracker.imported_targets[tt.file_path][chosen_name]

--- a/py-smelt/pysmelt/interfaces/procedural.py
+++ b/py-smelt/pysmelt/interfaces/procedural.py
@@ -16,7 +16,7 @@ def import_as_target(target_path: str) -> Target:
     chosen_name = tt.name
     if tt.file_path not in ImportTracker.imported_commands:
         targets, commands = parse_smelt(tt.file_path)
-        ImportTracker.imported_commands[tt.file_path] = commands
+        # ImportTracker.imported_commands[tt.file_path] = commands
         if chosen_name not in targets:
             raise RuntimeError(f"Could not find command {target_path}")
     dec_import_depth()

--- a/py-smelt/pysmelt/interfaces/procedural.py
+++ b/py-smelt/pysmelt/interfaces/procedural.py
@@ -17,7 +17,6 @@ def import_as_target(target_path: str) -> Target:
     if tt.file_path not in ImportTracker.imported_commands:
         targets, commands = parse_smelt(tt.file_path)
         ImportTracker.imported_commands[tt.file_path] = commands
-        ImportTracker.imported_targets[tt.file_path] = targets
     if chosen_name not in targets:
         raise RuntimeError(f"Could not find command {target_path}")
     dec_import_depth()

--- a/py-smelt/pysmelt/interfaces/runtime.py
+++ b/py-smelt/pysmelt/interfaces/runtime.py
@@ -9,22 +9,22 @@ class RuntimeRequirements:
     max_memory_mb: int
     # timeout in seconds
     timeout: int
-    # working_directory
-    env: Dict[str, str]
 
     @classmethod
-    def default(cls, env: Optional[Dict[str, str]] = None):
-        if env is None:
-            env = {}
-        return cls(num_cpus=1, max_memory_mb=1024, timeout=600, env=env)
+    def default(
+        cls,
+    ):
+
+        return cls(
+            num_cpus=1,
+            max_memory_mb=1024,
+            timeout=600,
+        )
 
     @classmethod
     def from_dict(cls, indict: Dict[str, Any]):
         num_cpus = indict["num_cpus"]
         max_memory_mb = indict["max_memory_mb"]
         timeout = indict["timeout"]
-        env = indict["env"]
 
-        return cls(
-            num_cpus=num_cpus, max_memory_mb=max_memory_mb, timeout=timeout, env=env
-        )
+        return cls(num_cpus=num_cpus, max_memory_mb=max_memory_mb, timeout=timeout)

--- a/py-smelt/pysmelt/interfaces/target.py
+++ b/py-smelt/pysmelt/interfaces/target.py
@@ -188,3 +188,6 @@ class Target(ABC):
                 outputs=outputs,
                 working_dir=working_dir,
             )
+
+    def __post_init__(self):
+        pass

--- a/py-smelt/pysmelt/pygraph.py
+++ b/py-smelt/pysmelt/pygraph.py
@@ -40,22 +40,6 @@ def default_cfg() -> ConfigureSmelt:
     return rv
 
 
-def default_target_rerun_callback(
-    target: Target, return_code: int
-) -> Tuple[Target, bool]:
-    """
-    First pass at re-run logic -- currently we just rerun all tests that are tagged as tests
-
-    Power users could supply their own logic, but we should define something that is robust and sane
-    """
-
-    requires_rerun = target.rule_type() == SmeltTargetType.Test and return_code != 0
-    
-    new_target = replace(target, name=f"{target.name}_rerun")
-    new_target.injected_state={"debug": "True"}
-
-    return (new_target, requires_rerun)
-
 
 def maybe_get_message(
     listener: PyEventStream, blocking: bool = False
@@ -200,7 +184,7 @@ class PyGraph:
 
     def rerun(
         self,
-        rerun_callback: RerunCallback = default_target_rerun_callback,
+
     ):
         raise NotImplementedError("Currently re-writing this -- please file an issue if this is load bearing!")
 

--- a/py-smelt/pysmelt/smelt_muncher.py
+++ b/py-smelt/pysmelt/smelt_muncher.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 import functools
 import yaml
 import pathlib
-from typing import ClassVar, Dict, Any, Iterable, Set, Tuple, Type, List
+from typing import ClassVar, Dict, Any, Iterable, Optional, Set, Tuple, Type, List
 from pydantic import BaseModel
 from pysmelt.generators.procedural import get_procedural_targets
 from pysmelt.importer import (
@@ -163,13 +163,20 @@ def create_universe(
     return SmeltUniverse(top_file=top_file, commands=all_commands)
 
 
-def target_to_command(target: Target, working_dir: str) -> Command:
+def target_to_command(
+    target: Target, working_dir: str
+) -> Tuple[Command, Optional[Command], Optional[Command]]:
     rc = SmeltRcHolder.current_rc()
     return Command.from_target(target, working_dir)
 
 
 def lower_targets_to_commands(targets: Iterable[Target], path: str) -> List[Command]:
-    return [target_to_command(target, path) for target in targets]
+    return [
+        command
+        for target in targets
+        for command in target_to_command(target, path)
+        if command
+    ]
 
 
 def smelt_contents_to_targets(

--- a/py-smelt/pysmelt/smelt_muncher.py
+++ b/py-smelt/pysmelt/smelt_muncher.py
@@ -37,7 +37,6 @@ def populate_rule_args(
 ) -> PreTarget:
     rule_payload.rule_args["name"] = target_name
     if rule_payload.rule not in all_rules:
-        print(all_rules)
 
         # TODO: make a pretty error that
         #
@@ -76,6 +75,8 @@ def parse_smelt(
 ) -> Tuple[Dict[str, Target], List[Command]]:
     test_list_orig = test_list
     targets = get_targets(test_list, default_rules_only)
+    ImportTracker.imported_targets[ImportTracker.local_file_alias()] = targets
+    ImportTracker.imported_targets[test_list] = targets
     command_list = lower_targets_to_commands(
         targets.values(), str(pathlib.Path(test_list_orig.to_abs_path()).parent)
     )
@@ -116,7 +117,6 @@ def create_universe(
     all_commands[top_file] = commands
     all_commands.update(ImportTracker.imported_commands)
     ImportTracker.clear()
-    ImportTracker.imported_targets[ImportTracker.local_file_alias()] = targets
 
     # Determine new files that are visible but not yet parsed
     new_files = visible_files - seen_files

--- a/py-smelt/pysmelt/smelt_muncher.py
+++ b/py-smelt/pysmelt/smelt_muncher.py
@@ -77,10 +77,12 @@ def parse_smelt(
     targets = get_targets(test_list, default_rules_only)
     ImportTracker.imported_targets[ImportTracker.local_file_alias()] = targets
     ImportTracker.imported_targets[test_list] = targets
+
     command_list = lower_targets_to_commands(
         targets.values(), str(pathlib.Path(test_list_orig.to_abs_path()).parent)
     )
 
+    ImportTracker.imported_commands[test_list] = command_list
     return targets, command_list
 
 

--- a/py-smelt/pysmelt/tracker.py
+++ b/py-smelt/pysmelt/tracker.py
@@ -1,0 +1,46 @@
+from dataclasses import dataclass
+
+from typing import ClassVar, Dict, List, Optional
+
+
+from typing import TYPE_CHECKING
+
+from pysmelt.interfaces.paths import SmeltPath, TempTarget
+
+
+if TYPE_CHECKING:
+
+    from pysmelt.interfaces.command import Command
+    from pysmelt.interfaces.target import Target, TargetRef
+
+
+@dataclass
+class ImportTracker:
+    imported_commands: ClassVar[Dict[SmeltPath, List["Command"]]] = {}
+    imported_targets: ClassVar[Dict[SmeltPath, Dict[str, "Target"]]] = {}
+
+    @staticmethod
+    def clear():
+        ImportTracker.imported_commands = {}
+
+    @staticmethod
+    def clear_all():
+        ImportTracker.imported_commands = {}
+
+    @staticmethod
+    def local_file_alias():
+        return SmeltPath("local")
+
+    @staticmethod
+    def get_all_imported() -> Dict[SmeltPath, List["Command"]]:
+        return ImportTracker.imported_commands
+
+
+def try_get_target(target: "TargetRef") -> Optional["Target"]:
+    tt = TempTarget.parse_string_smelt_target(
+        target, ImportTracker.local_file_alias().path
+    )
+    try:
+        return ImportTracker.imported_targets[tt.file_path][tt.name]
+    except Exception as _:
+        return None

--- a/pytests/test_graphs_simple.py
+++ b/pytests/test_graphs_simple.py
@@ -37,20 +37,18 @@ def test_get_cfg():
     graph = create_graph(test_list)
 
 
-#
-# def test_sanity_pygraph_rerun_nofailing():
-#    """
-#    Tests the case where no re-run is needed
-#    """
-#    test_list = f"{get_git_root()}/test_data/smelt_files/tests_only.smelt.yaml"
-#    graph = create_graph(test_list)
-#
-#    graph.run_all_tests("test")
-#    graph.rerun()
-#    # we have 3 tests, 0 of which fail -- so we should rerun no tests
-#    expected_executed_tasks = 3
-#    observed_reexec = graph.retcode_tracker.total_executed()
-#    assert observed_reexec == expected_executed_tasks, f"We don't re-run"
+def test_sanity_pygraph_rerun_nofailing():
+    """
+    Tests the case where no re-run is needed
+    """
+    test_list = f"{get_git_root()}/test_data/smelt_files/tests_only.smelt.yaml"
+    graph = create_graph(test_list)
+
+    graph.run_all_tests("test")
+    # we have 3 tests, 0 of which fail -- so we should rerun no tests
+    expected_executed_tasks = 3
+    observed_reexec = graph.retcode_tracker.total_executed()
+    assert observed_reexec == expected_executed_tasks, f"We don't re-run"
 
 
 def test_sanity_pygraph_runone():
@@ -64,37 +62,34 @@ def test_sanity_pygraph_runone():
     # we have 3 tests, 0 of which fail -- so we should rerun no tests
 
 
-# def test_sanity_pygraph_rerun_with_failing():
-#    test_list = f"{get_git_root()}/test_data/smelt_files/failing_tests_only.smelt.yaml"
-#    graph = create_graph(test_list)
-#    graph.run_all_tests("test")
-#    graph.rerun()
-#
-#    # we have 3 tests, 2 of which fail -- when we re-run, we only run those two
-#    # 5 total tests total
-#    expected_failing_tests = 5
-#    observed_reexec = graph.retcode_tracker.total_executed()
-#
-#    assert (
-#        observed_reexec == expected_failing_tests
-#    ), f"Expected to see {expected_failing_tests} tasks executed, saw {observed_reexec} tests"
-#
+def test_sanity_pygraph_rerun_with_failing():
+    test_list = f"{get_git_root()}/test_data/smelt_files/failing_tests_only.smelt.yaml"
+    graph = create_graph(test_list)
+    graph.run_all_tests("test")
+
+    # we have 3 tests, 2 of which fail -- when we re-run, we only run those two
+    # 5 total tests total
+    expected_failing_tests = 5
+    observed_reexec = graph.retcode_tracker.total_executed()
+
+    assert (
+        observed_reexec == expected_failing_tests
+    ), f"Expected to see {expected_failing_tests} tasks executed, saw {observed_reexec} tests"
 
 
-# def test_sanity_pygraph_new_build():
-#    test_list = f"{get_git_root()}/test_data/smelt_files/rerun_with_newbuild.smelt.yaml"
-#    graph = create_graph(test_list)
-#    graph.run_all_tests("test")
-#    graph.rerun()
-#
-#    # we have 3 tests, 2 of which fail
-#    # BUT we have a debug build that needs to be enabled
-#    expected_failing_tests = 6
-#    observed_reexec = graph.retcode_tracker.total_executed()
-#
-#    assert (
-#        observed_reexec == expected_failing_tests
-#    ), f"Expected to see {expected_failing_tests} tasks executed, saw {observed_reexec} tests"
+def test_sanity_pygraph_new_build():
+    test_list = f"{get_git_root()}/test_data/smelt_files/rerun_with_newbuild.smelt.yaml"
+    graph = create_graph(test_list)
+    graph.run_all_tests("test")
+
+    # we have 3 tests, 2 of which fail
+    # BUT we have a debug build that needs to be enabled
+    expected_failing_tests = 6
+    observed_reexec = graph.retcode_tracker.total_executed()
+
+    assert (
+        observed_reexec == expected_failing_tests
+    ), f"Expected to see {expected_failing_tests} tasks executed, saw {observed_reexec} tests"
 
 
 def test_sanity_pygraph_docker(simple_docker_image):
@@ -194,4 +189,4 @@ def test_split_build():
     ), f"Expected to see {expected_passed} tasks passed, saw {passed_commands} tests"
 
 
-test_split_build()
+test_sanity_pygraph_new_build()

--- a/pytests/test_graphs_simple.py
+++ b/pytests/test_graphs_simple.py
@@ -189,4 +189,17 @@ def test_split_build():
     ), f"Expected to see {expected_passed} tasks passed, saw {passed_commands} tests"
 
 
-test_sanity_pygraph_new_build()
+def test_sanity_procedural():
+    test_list = f"{get_git_root()}/test_data/smelt_files/procedural.py"
+    graph = create_graph(test_list)
+    graph.run_all_tests("test")
+
+    expected_tests = 5
+    observed_reexec = graph.retcode_tracker.total_executed()
+
+    assert (
+        observed_reexec == expected_tests
+    ), f"Expected to see {expected_tests} tasks executed, saw {observed_reexec} tests"
+
+
+test_sanity_procedural()

--- a/test_data/smelt_files/failing_tests_only.smelt.yaml
+++ b/test_data/smelt_files/failing_tests_only.smelt.yaml
@@ -1,5 +1,5 @@
 - name: fail_test_example_1
-  rule: raw_bash 
+  rule: raw_bash
   rule_args:
     cmds:
       - echo "test1"
@@ -9,16 +9,16 @@
   rule: raw_bash
   rule_args:
     cmds:
-      - echo "test2" 
-      - exit 0
+      - echo "test2"
+      - exit 1
     debug_cmds:
-      - echo "test2_rerun" 
+      - echo "test2_rerun"
 
 - name: fail_test_example_3
   rule: raw_bash
   rule_args:
     cmds:
-      - echo "test3" 
+      - echo "test3"
       - exit 1
     debug_cmds:
-      - echo "test3_rerun" 
+      - echo "test3_rerun"

--- a/test_data/smelt_files/procedural.py
+++ b/test_data/smelt_files/procedural.py
@@ -1,0 +1,5 @@
+from pysmelt.interfaces.procedural import import_as_target
+from pysmelt.default_targets import test_group, raw_bash
+
+for i in range(5):
+    raw_bash(name=f"my_test_{i}", cmds=[f'echo "howdy partner from test {i}"'])

--- a/test_data/smelt_files/rerun_with_newbuild.smelt.yaml
+++ b/test_data/smelt_files/rerun_with_newbuild.smelt.yaml
@@ -3,7 +3,7 @@
   rule_args:
     cmds:
       - echo "dummy build"
-    debug_cmds:
+    rebuild_cmds:
       - echo "dummy debug build"
 
 - name: cmark


### PR DESCRIPTION
this includes all the changes required for re-running, and significantly refactors the command generation process. 


# Previously 

Each command would map to a target, and we would use the classmethod `Command.from_target(target: Target, working_dir: str)` to do this "lowering" step from Target to Command, and we had ~6 methods on the `Target` class that would be called inside of `Command.from_target` to populate the fields of the command. The only method required to implement target was `gen_script`.

# Currently 

Targets now generate up to 3 Commands:

* base 
* rerun 
* rebuild 

where the rerun command is the command that runs on failure, and the rebuild command is the command that can be called by the re-running commands 

more interestingly, the semantics of lowering from Target -> Command have changed -- now we have 3 methods on `Target` to create commands: 

```python 
def to_command(self, working_dir: str) -> Command:
        return self._default_to_command(working_dir)

def to_rerun_command(self, working_dir: str) -> Optional[Command]:
        return self.default_rerun_command(working_dir)

def to_rebuild_command(self, working_dir: str) -> Optional[Command]:
        return self.default_rebuild_command(working_dir)
``` 

the `default_` methods use methods like `get_dependencies` and `get_dependent_files` to populate fields in commands, but at the end of the day, end users can now directly ovverride this function to have very fine grained control on how targets are converted into commands.

IMO, this gives us a good spectrum of "power": 

at the simple end, if an end user doesnt care about dependencies in smelt and only wants re-run, all they need to do is implement:

`gen_script` and `gen_rerun_script` to get re-running working. 

On the otherside of the spectrum, if people want to toggle special behaviour for paticular types of commands -- e.g. if they want to have timeout be double the normal timeout only for rerun commands, then they could impl:

``` python 
def to_rerun_command(self, working_dir: str) -> Command:
    command = self.default_rerun_command(working_dir)
    command.runtime.timeout *=2
    return command
```

Everything else has been implemented to spec from what we discussed -- this also adds a few tests
