### PR TITLE
update to 0.5.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*", "py-smelt"]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 authors = ["James Connolly <james@silogy.io>"]
 edition = "2021"
 

--- a/py-smelt/pyproject.toml
+++ b/py-smelt/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pysmelt"
-version = "0.5.0"
+version = "0.5.1"
 description = "smelt is a system to describe, run, and analyze integration tests"
 requires-python = ">=3.8"
 dependencies = [

--- a/py-smelt/pysmelt/interfaces/target.py
+++ b/py-smelt/pysmelt/interfaces/target.py
@@ -19,12 +19,6 @@ class SmeltTargetType(Enum):
     Rerun = "rerun"
 
 
-class CGVar(Enum):
-    base = "base"
-    rerun = "rerun"
-    rebuild = "rebuild"
-
-
 TargetRef = str
 
 

--- a/py-smelt/pysmelt/smelt_muncher.py
+++ b/py-smelt/pysmelt/smelt_muncher.py
@@ -129,7 +129,7 @@ def create_universe(
     targets, commands = parse_smelt(starting_file, default_rules_only)
     for comm in commands:
         for dep in comm.dependencies:
-            tt = TempTarget.parse_string_smelt_target(dep, starting_file.to_abs_path())
+            tt = TempTarget.parse_string_smelt_target(dep, starting_file.path)
             visible_files.add(tt.file_path)
     all_commands[top_file] = commands
     all_commands.update(ImportTracker.imported_commands)
@@ -151,9 +151,7 @@ def create_universe(
             # Add dependencies of new commands to new files if not seen
             for command in new_commands:
                 for dep in command.dependencies:
-                    tt = TempTarget.parse_string_smelt_target(
-                        dep, starting_file.to_abs_path()
-                    )
+                    tt = TempTarget.parse_string_smelt_target(dep, file.path)
                     if tt.file_path not in seen_files:
                         new_files.add(tt.file_path)
 

--- a/website/docs/intro.mdx
+++ b/website/docs/intro.mdx
@@ -16,13 +16,13 @@ variants, run those tests in parallel, and analyze their results. Smelt
 provides simple and efficient workflows to both local and distributed compute
 contexts.
 
-Smelt is distributed as a Python package and can be installed via:
+Smelt is distributed as a python package and can be installed via:
 
 `pipx install pysmelt`
 
 With smelt installed, you can describe a test list using a simple [YAML][yaml]
-schema in a file with a `.smelt.yaml` extension or procedurally with Python.
-A snippet of a Python testlist from [yves][yves]:
+schema in a file with a `.smelt` extension or procedurally with python.
+A snippet of a python testlist from [yves][yves]:
 
 ```py title="frontend_tl.py"
 num_branches = 1024
@@ -57,7 +57,7 @@ dbh = test_group(name="directional_branch_history_sweep", tests=branch_tests)
 ftcg = test_group(name="all_frontend_tests", tests=[dbh.as_ref])
 ```
 
-You can define a hierarchical test group that depends on these tests and others:
+there is a hierarchal test group that depends on these tests and others:
 
 ```yaml title="all.smelt.yaml"
 - name: all_tests
@@ -85,11 +85,11 @@ inspected, re-run, and modified.
 Built for EDA (electronic design automation), smelt seeks to unify the "best
 practices" for testing infrastructure:
 
-- Procedural test generation: Programatically generate tests with Python
-- Automatic rerun on failure: Describe the computation required to re-run
-  failing tests
+- Procedural test generation: Programatically generate tests with python
+- Automatic rerun on failure: Describe the computation required re-run failing
+  tests
 - Analysis APIs: All of the data needed to track and reproduce tests
-- Extensible: Define your tests with a simple Python interface
+- Extensible: Define your tests with a simple python interface
 
 {/* prettier-ignore-start */}
 [make]: https://www.gnu.org/software/make/


### PR DESCRIPTION
fixes a bug where the same path was getting registered -- need to root cause why this wasn't getting caught in our tests, this was found in a fairly innocuous text example in prod