### PR TITLE
fix test only

### DIFF
--- a/crates/smelt-graph/src/graph.rs
+++ b/crates/smelt-graph/src/graph.rs
@@ -119,6 +119,10 @@ impl Key for CommandRef {
         ctx: &mut DiceComputations,
         _cancellations: &CancellationContext,
     ) -> Self::Value {
+        if ctx.global_data().get_smelt_cfg().test_only && self.0.target_type != TargetType::Test {
+            return Ok(Arc::new(ExecutedTestResult::Skipped));
+        }
+
         let deps = self.0.dependencies.as_slice();
         let req_files = self.0.dependent_files.as_slice();
         let (command_deps, file_command_deps) = get_command_deps(ctx, deps, req_files).await;

--- a/py-smelt/pysmelt/pygraph.py
+++ b/py-smelt/pysmelt/pygraph.py
@@ -96,6 +96,9 @@ class PyGraph:
 
     additional_listeners: List[SmeltSub]
 
+    def commands(self):
+        return self.universe.top_level_commands
+
     def runloop(self, listener: PyEventStream):
         errhandler = SmeltErrorHandler()
         invbuilder = InvocationBuilder()


### PR DESCRIPTION
I added this flag a while back but never pushed it across the finish line 

this allows for test and build to be fully decoupled -- anything that isnt a test target will be skipped. 

this is useful for quickly re-running tests without doing the rebuild steps