### PR TITLE
bumps the graph timeout, also adds some telemetry

### DIFF
--- a/crates/smelt-graph/src/executor/slurm.rs
+++ b/crates/smelt-graph/src/executor/slurm.rs
@@ -256,12 +256,16 @@ async fn foward_task(
     host: String,
 ) -> anyhow::Result<()> {
     let mut client = EventSubscriberClient::connect(host).await?;
+
     let stuff = client
         .subscribe_received_events(tonic::Request::new(smelt_data::ExecutionSubscribe {
-            trace_id,
+            trace_id: trace_id.clone(),
         }))
         .await
         .inspect_err(|e| tracing::error!("Failed to subscribe to the server with err {e:?}"))?;
+
+    tracing::info!("Successfully created tunnel to smelt-slurm-server with trace_id {trace_id}");
+
     let mut stream = stuff.into_inner();
     tracing::trace!(
         "Successfully connected -- forwarding messages to the correct place, stream is {stream:?}"

--- a/crates/smelt-graph/src/graph.rs
+++ b/crates/smelt-graph/src/graph.rs
@@ -497,9 +497,8 @@ impl CommandGraph {
     // This should hopefully never return
     pub async fn eat_commands(&mut self) {
         use tokio::time::timeout;
-        //TODO: maybe this should be configurable
-        //      in practice for most end users, this shouldnt come up
-        let duration = tokio::time::Duration::from_secs(1200);
+
+        let duration = tokio::time::Duration::from_secs(3600 * 24);
         loop {
             let result = timeout(duration, self.rx_chan.recv()).await;
 
@@ -529,7 +528,7 @@ impl CommandGraph {
                 }
                 let _ = oneshot_confirmer.send(rv);
             } else if result.is_err() {
-                tracing::warn!("We have elapsed on our timeout for new commands to come in -- exiting from the eatcommand loop");
+                tracing::warn!("We have elapsed on our timeout for new commands to come in after waiting {duration:?} -- exiting from the eatcommand loop");
             }
         }
     }

--- a/crates/smelt-slurm-server/src/server.rs
+++ b/crates/smelt-slurm-server/src/server.rs
@@ -6,8 +6,8 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 use std::{net::SocketAddr, pin::Pin};
 
 use smelt_data::{
-    event_subscriber_server::EventSubscriber,
-    Event, ExecutionFinish, ExecutionSubscribe, TaggedResult,
+    event_subscriber_server::EventSubscriber, Event, ExecutionFinish, ExecutionSubscribe,
+    TaggedResult,
 };
 
 use scc::HashMap;
@@ -37,6 +37,7 @@ impl EventSubscriber for GlobalSlurmServer {
     ) -> std::result::Result<tonic::Response<EventStream>, tonic::Status> {
         let trace_id = request.into_inner().trace_id;
         let (send, rcv) = unbounded_channel();
+        tracing::info!("Starting job run for trace id {}", trace_id.clone());
         let _ = self.senders.insert_async(trace_id, send).await;
 
         let strm: EventStream = Box::pin(UnboundedReceiverStream::new(rcv).map(Ok));
@@ -47,6 +48,7 @@ impl EventSubscriber for GlobalSlurmServer {
         request: tonic::Request<ExecutionFinish>,
     ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
         let trace = request.into_inner().trace_id;
+        tracing::info!("Ending subscription for trace {}", trace.clone());
         self.senders.remove_async(&trace).await;
         Ok(tonic::Response::new(()))
     }

--- a/crates/smelt-slurm/src/lib.rs
+++ b/crates/smelt-slurm/src/lib.rs
@@ -60,7 +60,8 @@ pub async fn execute_command(
             command_name.to_string(),
             trace_id.clone(),
         ))
-        .await?;
+        .await
+        .inspect_err(|ee| eprintln!("failed to initialize event listener {ee}"))?;
     let stdout = working_dir.join(Command::stdout_file());
     let script_file = working_dir.join(Command::script_file());
 
@@ -172,11 +173,7 @@ pub async fn execute_command(
     }
 
     let _ = stream
-        .send_event(Event::command_finished(
-            res,
-            "test".to_string(),
-            trace_id,
-        ))
+        .send_event(Event::command_finished(res, "test".to_string(), trace_id))
         .await;
 
     if let Some(task) = sample_task {


### PR DESCRIPTION
adds timeout bump -- previously if a graph was live for 20 minutes, it would timeout and then exit -- an issue for any tasks that were still being run.

that timeout has been bumped to 24 hours -- also added some telemetry for the slurm-server when it registers and de-registers, as well as the client side when it successfully establishes a tunnel.

my guess on the fails we were seeing is that commands on the smelt side would get queued up, and the timeout would fire and the future would be cancelled before a tunnel was established. then when the corresponding test would run on our cluster, we would see no tunnel existed and we'd fail. 

regardless the extra telemetry should be helpful in debugging 